### PR TITLE
User data is independent now

### DIFF
--- a/src/api/hooks/following.ts
+++ b/src/api/hooks/following.ts
@@ -1,9 +1,28 @@
 import useSWR from 'swr'
+import { useCallback } from 'react'
 
 import { getUserFollowing } from '../methods'
 
 export function useUserFollowing() {
-  return useSWR('getUserFollowing', getUserFollowing, {
+  const { data, ...rest } = useSWR('getUserFollowing', getUserFollowing, {
     revalidateIfStale: false,
   })
+  const checkVaccineFollowed = useCallback(
+    (vaccineId?: number) => {
+      return data?.followingVaccines.some((vaccine) => vaccine.ID === vaccineId) || false
+    },
+    [data]
+  )
+  const checkArticleFollowed = useCallback(
+    (articleId?: number) => {
+      return data?.followingArticles.some((article) => article.ID === articleId) || false
+    },
+    [data]
+  )
+  return {
+    ...rest,
+    checkVaccineFollowed,
+    checkArticleFollowed,
+    data,
+  }
 }

--- a/src/api/hooks/profiles.ts
+++ b/src/api/hooks/profiles.ts
@@ -1,4 +1,5 @@
 import useSWR from 'swr'
+import { useCallback } from 'react'
 
 import { getProfiles } from '..'
 
@@ -7,18 +8,20 @@ export function useProfiles() {
     revalidateIfStale: false,
   })
 
-  function id2name(id?: number) {
-    return data?.find((v) => v.ID === id)?.fullName
-  }
+  const id2name = useCallback(
+    (id?: number) => data?.find((v) => v.ID === id)?.fullName,
+    [data]
+  )
 
-  function selectByID(id?: number) {
-    return data?.find((v) => v.ID === id)
-  }
+  const selectByID = useCallback(
+    (id?: number) => data?.find((v) => v.ID === id),
+    [data]
+  )
 
   return {
     ...rest,
     data,
     id2name,
-    selectByID
+    selectByID,
   }
 }

--- a/src/api/hooks/vaccines.ts
+++ b/src/api/hooks/vaccines.ts
@@ -1,21 +1,14 @@
 import useSWR from 'swr'
+import { useCallback } from 'react'
+import { getVaccineList } from '../methods'
 
-import { getVaccineList, Vaccine } from '../methods'
-
-// TODO: maintain 'followed', 'order', 'history', 'expired' states
 export function useVaccines() {
-  const { data: raw, ...rest } = useSWR('getVaccineList', getVaccineList, {
+  const { data, ...rest } = useSWR('getVaccineList', getVaccineList, {
     revalidateIfStale: false,
   })
-  const data = raw as Pick<Vaccine, 'name' | 'ID'>[]
+  const name2id = useCallback((name?: string) => data?.find((v) => v.name === name)?.ID, [data])
 
-  function name2id(name?: string) {
-    return data?.find((v) => v.name === name)?.ID
-  }
-
-  function id2name(id?: number) {
-    return data?.find((v) => v.ID === id)?.name
-  }
+  const id2name = useCallback((id?: number) => data?.find((v) => v.ID === id)?.name ?? '', [data])
 
   return {
     ...rest,

--- a/src/api/methods.tsx
+++ b/src/api/methods.tsx
@@ -136,30 +136,13 @@ export async function getVaccineList(): Promise<Vaccine[]> {
   return response.data
 }
 
-export async function getVaccineByID(id: string): Promise<Vaccine> {
-  const response = await api.get('/api/vaccines/' + id)
-  return response.data
-}
-
 export async function getVaccineRecordList(): Promise<VaccinationRecord[]> {
-  const response = await api.get('/api/vaccination-records')
-  // 将要替换为：
-  // const response = await api.get('/api/vaccination-records/user/' + getUserID())
-  return response.data
-}
-
-export async function getVaccineRecordWithProfile(profileId: number): Promise<VaccinationRecord[]> {
-  const response = await api.get('/api/vaccination-records/profile/' + profileId)
+  const response = await api.get('/api/vaccination-records/user/' + getUserID())
   return response.data
 }
 
 export async function postVaccineRecord(data: Partial<VaccinationRecord>): Promise<VaccinationRecord> {
   const response = await api.post('/api/vaccination-records', data)
-  return response.data
-}
-
-export async function getVaccineRecord(id: number): Promise<VaccinationRecord> {
-  const response = await api.get('/api/vaccination-records/' + id)
   return response.data
 }
 
@@ -174,19 +157,20 @@ export async function putVaccineRecord(id: number, data: Partial<VaccinationReco
 }
 
 export async function getProfiles(): Promise<Profile[]> {
-  const response = await api.get('/api/profiles')
-  // 将要替换为：
-  // const response = await api.get('/api/profiles/user/' + getUserID())
+  const response = await api.get('/api/profiles/user/' + getUserID())
   return response.data
 }
 
 export async function postProfile(data: Partial<Profile>): Promise<Profile> {
-  const response = await api.post('/api/profiles', data)
+  const response = await api.post('/api/profiles', {
+    ...data,
+    userId: getUserID(),
+  })
   return response.data
 }
 
-export async function putProfile(data: Partial<Profile>): Promise<Profile> {
-  const response = await api.put('/api/profiles/' + data.ID, data)
+export async function putProfile(id: number, data: Partial<Profile>): Promise<Profile> {
+  const response = await api.put('/api/profiles/' + id, data)
   return response.data
 }
 
@@ -196,7 +180,34 @@ export async function deleteProfile(id: number): Promise<Profile> {
 }
 
 export async function getTemperatureRecordList(): Promise<TemperatureRecord[]> {
-  const response = await api.get('/api/temperature-records')
+  const response = await api.get('/api/temperature-records/user/' + getUserID())
+  return response.data
+}
+
+export async function postTemperatureRecord(data: Partial<TemperatureRecord>): Promise<TemperatureRecord> {
+  const response = await api.post('/api/temperature-records', data)
+  return response.data
+}
+
+export async function putTemperatureRecord(id: number, data: Partial<TemperatureRecord>): Promise<TemperatureRecord> {
+  const response = await api.put('/api/temperature-records/' + id, data)
+  return response.data
+}
+
+export async function deleteTemperatureRecord(id: number): Promise<string> {
+  const response = await api.delete('/api/temperature-records/' + id)
+  return response.data
+}
+
+export async function getTopArticlesWithVaccine(
+  vaccineid: number
+): Promise<Article[]> {
+  const response = await api.get('/api/articles', {
+    page: 1,
+    size: 2,
+    isBind: true,
+    vaccineID: vaccineid,
+  })
   return response.data
 }
 
@@ -223,13 +234,6 @@ export async function getMyArticles(): Promise<Article[]> {
 export async function deleteArticle(id: number): Promise<string> {
   const response = await api.delete('/api/articles/' + id)
   return response.data
-}
-
-export async function getArticleFullByID(id?: string): Promise<ArticleFull> {
-  if (!id) return Promise.reject('id is empty')
-  const article = (await api.get('/api/articles/' + id)).data
-  const replies = (await api.get('/api/replys', { articleId: id })).data
-  return { ...article, replies }
 }
 
 export async function getArticleByID(id: number): Promise<Article> {

--- a/src/app.config.ts
+++ b/src/app.config.ts
@@ -27,7 +27,7 @@ export default defineAppConfig({
   window: {
     backgroundTextStyle: 'light',
     navigationBarBackgroundColor: '#fff',
-    navigationBarTitleText: 'WeChat',
+    navigationBarTitleText: '',
     navigationBarTextStyle: 'black',
   },
   permission: {

--- a/src/models/enquiry.ts
+++ b/src/models/enquiry.ts
@@ -1,0 +1,36 @@
+import { create } from 'zustand'
+import { immer } from 'zustand/middleware/immer'
+import createSelectors from './selectors'
+
+interface State {
+  filter: number | string | undefined
+  expandProfileFilter: boolean
+}
+
+interface Action {
+  toggleProfileFilter: (filter?: number | string) => void
+  toggleExpandFilter: () => void
+}
+
+const initialState: State = {
+  filter: undefined,
+  expandProfileFilter: true,
+}
+
+const Store = create<State & Action>()(
+  immer((set, _get) => ({
+    ...initialState,
+    toggleProfileFilter(profileId) {
+      set((state) => {
+        state.filter = state.filter === profileId ? undefined : profileId
+      })
+    },
+    toggleExpandFilter() {
+      set((state) => {
+        state.expandProfileFilter = !state.expandProfileFilter
+      })
+    },
+  }))
+)
+
+export const useEnquiryStore = createSelectors(Store)

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -4,3 +4,4 @@ export * from "./device";
 export * from "./recordpopup";
 export * from "./community";
 export * from "./calendar";
+export * from "./enquiry";

--- a/src/models/tabindex.ts
+++ b/src/models/tabindex.ts
@@ -4,11 +4,15 @@ import createSelectors from "./selectors";
 interface ITabIndexStore {
   tabIndex: number;
   setTabIndex: (index: number) => void;
+  actionVisible: boolean
+  setActionVisible: (visible: boolean) => void
 }
 
 const tabindexStore = create<ITabIndexStore>()((set) => ({
   tabIndex: 0,
   setTabIndex: (index: number) => set((_state) => ({ tabIndex: index })),
+  actionVisible: false,
+  setActionVisible: (visible: boolean) => set((_state) => ({ actionVisible: visible })),
 }));
 
 export const useTabStore = createSelectors(tabindexStore);

--- a/src/pages/community/articlepage/index.tsx
+++ b/src/pages/community/articlepage/index.tsx
@@ -146,7 +146,7 @@ const BottomBar = (props: { article_id: number; onSubmit: any }) => {
 }
 
 const FollowButton = (props: { article_id: number }) => {
-  const { data: user, mutate } = useUserFollowing()
+  const { checkArticleFollowed: isArticleFollowed, mutate } = useUserFollowing()
   const handleFollowClick = async () => {
     await followArticle(props.article_id)
     mutate()
@@ -155,7 +155,7 @@ const FollowButton = (props: { article_id: number }) => {
     await unfollowArticle(props.article_id)
     mutate()
   }
-  const following = user?.followingArticles?.find((a) => a.ID === props.article_id) !== undefined
+  const following = isArticleFollowed(props.article_id)
   return following ? (
     <HeartFill1 className='text-brand' size={16} onClick={handleUnfollowClick}></HeartFill1>
   ) : (

--- a/src/pages/community/index.tsx
+++ b/src/pages/community/index.tsx
@@ -96,7 +96,9 @@ const Header = () => {
                 <span className='text-2xl font-bold'>疫苗社区</span>
               </a>
               <div className='flex items-center' onClick={toggleExpand}>
-                <span className='pr-2 py-2 text-sm rounded-md'>筛选</span>
+                <span className='pr-2 py-2 text-sm rounded-md'>{
+                  filter ? '#'+data?.find(v => v.ID === filter)?.name : '筛选'
+                }</span>
                 <ArrowDown
                   size={10}
                   className={clsx('transition-all transform', {

--- a/src/pages/document/index.tsx
+++ b/src/pages/document/index.tsx
@@ -8,7 +8,7 @@ import { Tabs } from '@nutui/nutui-react-taro'
 import { IconFont } from '@nutui/icons-react-taro'
 import Taro from '@tarojs/taro'
 
-import { useProfiles, useVaccineRecordList, useTemperatureList } from '../../api'
+import { useProfiles, useVaccineRecordList, useTemperatureList, useVaccines } from '../../api'
 import { dayjs } from '../../utils'
 
 import { VaccinationRecord, TemperatureRecord } from '../../api/methods'
@@ -61,6 +61,7 @@ export default function RecordHistory() {
 const VaccineItemRender = ({ data }: { data: VaccinationRecord }) => {
   const { selectByID } = useProfiles()
   const profileInfo = selectByID(data.profileId)
+  const { id2name } = useVaccines()
 
   // const handleReadDocument = (recordData: VaccinationRecord) => {
   //   Taro.navigateTo({
@@ -86,7 +87,7 @@ const VaccineItemRender = ({ data }: { data: VaccinationRecord }) => {
       </div>
       <div className='flex justify-between mt-2'>
         <div className='text-gray-500'>
-          接种疫苗 <b className='text-black font-bold'>{data.vaccine.name}</b>
+          接种疫苗 <b className='text-black font-bold'>{id2name(data.vaccineId)}</b>
         </div>
         <div className='text-gray-500'>
           接种类型 <b className='text-black font-bold'>{data.vaccinationType}</b>

--- a/src/pages/enquiry/header.tsx
+++ b/src/pages/enquiry/header.tsx
@@ -1,0 +1,80 @@
+import { ArrowDown } from '@nutui/icons-react-taro'
+import clsx from 'clsx'
+
+import { useProfiles } from '../../api/'
+import { useEnquiryStore } from '../../models'
+
+export const Header = () => {
+  const { data } = useProfiles()
+  const filter = useEnquiryStore.use.filter()
+  const expand = useEnquiryStore.use.expandProfileFilter()
+  const toggleFilter = useEnquiryStore.use.toggleProfileFilter()
+  const toggleExpand = useEnquiryStore.use.toggleExpandFilter()
+
+  return (
+    <header
+      className={clsx('transition-all', {
+        'h-16': !expand,
+        'h-28': expand,
+      })}
+    >
+      <nav id='foo' className='fixed z-20 w-full backdrop-blur-md bg-gradient-to-b from-white to-white/80'>
+        <div className='m-auto px-6'>
+          <div className='flex flex-wrap items-center justify-between gap-6 py-3'>
+            <div className='flex w-full justify-between'>
+              <a className='flex items-center space-x-2'>
+                <span className='text-2xl font-bold'>疫苗查询</span>
+              </a>
+              <div className='flex items-center' onClick={toggleExpand}>
+                <span className='pr-2 py-2 text-sm rounded-md'>查询方法</span>
+                <ArrowDown
+                  size={10}
+                  className={clsx('transition-all transform', {
+                    'rotate-180': expand,
+                  })}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <ul
+          className={clsx('flex items-center px-4 gap-4 overflow-x-scroll whitespace-nowrap transition-all', {
+            'h-0 scale-y-0': !expand,
+            'h-12': expand,
+          })}
+        >
+          <li
+            className={clsx(
+              'flex items-center justify-center px-2 py-2 text-sm font-medium rounded-full',
+              'transition-colors',
+              {
+                'bg-slate-100 text-brand': filter === 'following',
+              }
+            )}
+            onClick={() => toggleFilter('following')}
+          >
+            收藏
+          </li>
+
+          {data?.map((member, index) => {
+            return (
+              <li
+                key={index}
+                className={clsx(
+                  'flex items-center justify-center px-2 py-2 text-sm font-medium rounded-full',
+                  'transition-colors',
+                  {
+                    'bg-slate-100 text-brand': filter === member.ID,
+                  }
+                )}
+                onClick={() => toggleFilter(member.ID)}
+              >
+                {member.fullName}的疫苗
+              </li>
+            )
+          })}
+        </ul>
+      </nav>
+    </header>
+  )
+}

--- a/src/pages/enquiry/index.tsx
+++ b/src/pages/enquiry/index.tsx
@@ -1,66 +1,23 @@
-import { useMemo } from 'react'
-import Taro from '@tarojs/taro'
-import { Elevator, Loading } from '@nutui/nutui-react-taro'
+import { Loading } from '@nutui/nutui-react-taro'
 
 import { useVaccines } from '../../api'
-
-type TElevatorItem = {
-  name: string
-  id: number
-}
-
-type TElevatorGroup = {
-  title: string
-  list: TElevatorItem[]
-}
+import { Header } from './header'
+import VaccineItem from './vaccineItem'
 
 export default function VaccineEnquiry() {
   const { data: vaccineList, isLoading } = useVaccines()
 
-  const getRenderList = (
-    data: {
-      name: string
-      ID: number
-    }[]
-  ) => {
-    const list: TElevatorGroup[] = []
-    data.forEach((item) => {
-      const firstChar = item.name.charAt(0)
-      const index = list.findIndex((group) => group.title === firstChar)
-      if (index === -1) {
-        list.push({
-          title: firstChar,
-          list: [
-            {
-              name: item.name,
-              id: item.ID,
-            },
-          ],
-        })
-      } else {
-        list[index].list.push({
-          name: item.name,
-          id: item.ID,
-        })
-      }
-    })
-    list.sort((a, b) => a.title.localeCompare(b.title))
-    return list
-  }
-
-  const renderlist = useMemo(() => vaccineList && getRenderList(vaccineList), [vaccineList])
-
-  const onItemClick = (_key: string, item: TElevatorItem) => {
-    Taro.navigateTo({ url: '/pages/vacDetails/index?id=' + item.id })
-  }
-
   return (
     <>
+      <Header />
       {isLoading ? (
         <Loading className='h-screen w-screen' />
       ) : (
-        <div className='flex flex-col p-2 h-without-tab'>
-          <Elevator list={renderlist} height='100%' onItemClick={onItemClick}></Elevator>
+        <div className='grid grid-cols-2 gap-x-5 gap-y-4 px-6'>
+          {vaccineList?.map((vaccine, index) => (
+            <VaccineItem key={index} {...vaccine} />
+          ))}
+          <div className='h-32' />
         </div>
       )}
     </>

--- a/src/pages/enquiry/vaccineItem.tsx
+++ b/src/pages/enquiry/vaccineItem.tsx
@@ -1,0 +1,67 @@
+import Taro from '@tarojs/taro'
+import clsx from 'clsx'
+import React from 'react'
+
+import { initialVaccineState, useUserFollowing, useVaccineRecordList, Vaccine } from '../../api'
+
+import { useEnquiryStore } from '../../models'
+
+type Props = Partial<Vaccine>
+
+const VaccineItem: React.FC<Props> = (props) => {
+  const { checkVaccineFollowed: isVaccineFollowed } = useUserFollowing()
+  const isCollected = isVaccineFollowed(props.ID)
+  const filter = useEnquiryStore.use.filter()
+  const { getVaccineState } = useVaccineRecordList()
+  const state = typeof filter === 'number' ? getVaccineState(filter, props.ID) : initialVaccineState
+
+  const handleItemClick = () => {
+    Taro.navigateTo({ url: '/pages/vacDetails/index?id=' + props.ID })
+  }
+
+  if (filter === 'following' && !isCollected) {
+    return null
+  }
+
+  return (
+    <div
+      className={clsx(
+        'relative overflow-hidden flex h-16 items-center p-2 rounded-md bg-gray-100',
+        'active: scale-105 active:shadow-lg transition-all'
+      )}
+      onClick={handleItemClick}
+    >
+      <span
+        className={clsx('absolute inset-x-0 bottom-0 h-1', {
+          'bg-gradient-to-r from-brand to-green-200': state.inEffect,
+          'bg-gradient-to-r from-brand to-red-200': state.inoculated && !state.inEffect,
+          'bg-gradient-to-r from-brand to-gray-200': state.planning,
+        })}
+      ></span>
+
+      <div>
+        <div className='flex items-center'>
+          <h2
+            className={clsx('text-sm font-semibold truncate transition-colors', {
+              'text-brand': isCollected && typeof filter !== 'number',
+            })}
+          >
+            {props.name}
+          </h2>
+          <div className='absolute right-0 w-1/3 h-14 bg-gradient-to-r from-transparent to-gray-100'></div>
+        </div>
+        <div
+          className={clsx('absolute text-[10px] right-1 bottom-2 px-1.5 py-0.5 rounded-full', {
+            'bg-slate-200 text-brand': state.inEffect,
+            'bg-red-100 text-red-400': state.inoculated && !state.inEffect,
+            'bg-gray-200 text-gray-500': state.planning,
+          })}
+        >
+          {state.inEffect ? '生效' : state.inoculated && !state.inEffect ? '过期' : state.planning ? '计划' : ''}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default VaccineItem

--- a/src/pages/record_history/index.tsx
+++ b/src/pages/record_history/index.tsx
@@ -3,7 +3,7 @@ import { Button, Menu } from '@nutui/nutui-react-taro'
 import { IconFont, Edit } from '@nutui/icons-react-taro'
 import Taro from '@tarojs/taro'
 
-import { useProfiles, useVaccineRecordList } from '../../api'
+import { useProfiles, useVaccineRecordList, useVaccines } from '../../api'
 
 import { VaccinationRecord } from '../../api/methods'
 import { dayjs } from '../../utils'
@@ -62,6 +62,7 @@ export default function RecordHistory() {
 const ItemRender = ({ data }: { data: VaccinationRecord }) => {
   const { selectByID } = useProfiles()
   const profileInfo = selectByID(data.profileId)
+  const { id2name } = useVaccines()
 
   const handleEditRecord = (recordData: VaccinationRecord) => {
     Taro.navigateTo({
@@ -88,7 +89,7 @@ const ItemRender = ({ data }: { data: VaccinationRecord }) => {
       </div>
       <div className='flex justify-between mt-2'>
         <div className='text-gray-500'>
-          接种疫苗 <b className='text-black font-bold'>{data.vaccine.name}</b>
+          接种疫苗 <b className='text-black font-bold'>{id2name(data.vaccineId)}</b>
         </div>
         <div className='text-gray-500'>
           接种类型 <b className='text-black font-bold'>{data.vaccinationType}</b>

--- a/src/pages/temper/index.tsx
+++ b/src/pages/temper/index.tsx
@@ -8,7 +8,8 @@ import { Text } from '@tarojs/components'
 import { Picker, Range, DatePicker, Cell, Button, TextArea, InputNumber } from '@nutui/nutui-react-taro'
 import { PickerOption } from '@nutui/nutui-react-taro/dist/types/packages/picker/types'
 
-import api, { TemperatureRecord, useProfiles, useTemperatureList } from '../../api'
+import { TemperatureRecord, postTemperatureRecord, putTemperatureRecord } from '../../api'
+import { useProfiles, useTemperatureList } from '../../api/hooks'
 
 export default function TemperRecord() {
   const { data: profiles } = useProfiles()
@@ -27,7 +28,7 @@ export default function TemperRecord() {
         try {
           const result = allTemperatures?.find((item) => item.ID === Number(router?.params.id))
           if (!result) {
-          // TODO: handle 404
+            // TODO: handle 404
             return
           }
           const relation = MemberData.find((item) => item.value === result.profileId)
@@ -111,7 +112,7 @@ export default function TemperRecord() {
       const { id } = router.params
       if (id) {
         try {
-          await api.request({ url: `/api/temperature-records/${id}`, method: 'PUT', data: tempRecord })
+          await putTemperatureRecord(Number(id), tempRecord)
           refreshTemperatureCache()
           Taro.showToast({ title: '提交成功', icon: 'success' })
           setTimeout(() => {
@@ -126,7 +127,7 @@ export default function TemperRecord() {
     } else {
       if (tempRecord && tempRecord.profileId !== undefined && tempRecord.profileId >= 0) {
         try {
-          await api.request({ url: '/api/temperature-records', method: 'POST', data: tempRecord })
+          await postTemperatureRecord(tempRecord)
           refreshTemperatureCache()
           Taro.showToast({ title: '提交成功', icon: 'success' })
           setTimeout(() => {

--- a/src/pages/vacCalendar/recordPopup.tsx
+++ b/src/pages/vacCalendar/recordPopup.tsx
@@ -7,7 +7,7 @@ import { Date as DateIcon, Clock, Checked, Order, Edit, Del2 } from '@nutui/icon
 import InjectSVG from '../../assets/home/injection.svg'
 
 import { useRecordPopup } from '../../models'
-import { useProfiles, useVaccineRecordList, deleteVaccineRecord, putVaccineRecord } from '../../api'
+import { useProfiles, useVaccineRecordList, deleteVaccineRecord, putVaccineRecord, useVaccines } from '../../api'
 
 export default function RecordPopup() {
   const recordID = useRecordPopup.use.recordId()
@@ -16,6 +16,8 @@ export default function RecordPopup() {
   const clear = useRecordPopup.use.clear()
 
   const { data: allRecords, mutate: refresh } = useVaccineRecordList()
+
+  const { id2name } = useVaccines()
 
   const record = useMemo(() => {
     if (!recordID) return undefined
@@ -50,7 +52,7 @@ export default function RecordPopup() {
       <div className='flex flex-col justify-center px-4 pt-2 pb-8'>
         <Nav />
 
-        <Header profileId={record?.profileId} vaccineName={record?.vaccine.name} />
+        <Header profileId={record?.profileId} vaccineName={id2name(record?.vaccineId)} />
         <GrayCard text={record?.vaccinationType || '类型'} />
 
         <DividerLine />

--- a/src/pages/vacCalendar/vacCalendarItem.tsx
+++ b/src/pages/vacCalendar/vacCalendarItem.tsx
@@ -6,7 +6,7 @@ import InjectSVG from '../../assets/home/injection.svg'
 
 import { dayjs } from '../../utils'
 import { VaccinationRecord } from '../../api/methods'
-import { useProfiles, useVaccineRecordList } from '../../api/hooks'
+import { useProfiles, useVaccineRecordList, useVaccines } from '../../api/hooks'
 import { useRecordPopup } from '../../models'
 
 export type VacCalendarData = {
@@ -41,6 +41,8 @@ export function VacCalendarItem({ key, record, hideOverlook = false }: VacCalend
   const { id2name } = useProfiles()
   const showPopup = useRecordPopup.use.show()
 
+  const { id2name: getVacname } = useVaccines()
+
   const overlook = record.isCompleted
   const needWarning = !record.isCompleted && dayjs(record.vaccinationDate).isBefore(dayjs())
   const timeError = record.isCompleted && dayjs(record.vaccinationDate).isAfter(dayjs())
@@ -66,7 +68,7 @@ export function VacCalendarItem({ key, record, hideOverlook = false }: VacCalend
         </div>
         <div className='flex flex-col'>
           <Text className='font-semibold text-brand'>
-            {id2name(record.profileId)} {record.vaccine.name} {record.isCompleted ? '已接种' : '未接种'}
+            {id2name(record.profileId)} {getVacname(record.vaccineId)} {record.isCompleted ? '已接种' : '未接种'}
           </Text>
           <Text className={clsx('text-xs', { 'text-red-500': timeError, 'text-gray-500': !timeError })}>
             接种：{record.vaccinationDate}
@@ -84,6 +86,8 @@ export function VacCalendarItemExpire({ key, record, hideOverlook = false }: Vac
   const { getVaccineState } = useVaccineRecordList()
   const state = getVaccineState(record.profileId, record.vaccineId)
 
+  const { id2name: getVacname } = useVaccines()
+
   if (record.isCompleted === false) return null
   const currentDate = dayjs()
   const overlook = state.inEffect && currentDate.isAfter(dayjs(record.nextVaccinationDate))
@@ -95,8 +99,9 @@ export function VacCalendarItemExpire({ key, record, hideOverlook = false }: Vac
     <li
       key={key}
       className={clsx(
-        'flex h-16 animate-fade-in flex-row items-center justify-between rounded-2xl bg-gray-100 px-4 transition-all active:scale-105 active:shadow-md',
+        'flex h-16 flex-row items-center justify-between rounded-2xl bg-gray-100 px-4 transition-all active:scale-105 active:shadow-md',
         {
+          'animate-fade-in': !overlook,
           'ring-2 ring-gray-500': needHighlight,
           'opacity-40': overlook,
         }
@@ -109,7 +114,7 @@ export function VacCalendarItemExpire({ key, record, hideOverlook = false }: Vac
         </div>
         <div className='flex flex-col'>
           <Text className='font-semibold'>
-            {id2name(record.profileId)} {record.vaccine.name}{' '}
+            {id2name(record.profileId)} {getVacname(record.vaccineId)}{' '}
             {overlook ? '已补种' : needHighlight ? '已过期' : '未过期'}
           </Text>
           <Text className='text-xs text-gray-500'>过期：{record.nextVaccinationDate}</Text>

--- a/src/pages/vacDetails/discussion.tsx
+++ b/src/pages/vacDetails/discussion.tsx
@@ -1,0 +1,76 @@
+import { Uploader, MoreX } from '@nutui/icons-react-taro'
+import Taro from '@tarojs/taro'
+import clsx from 'clsx'
+import useSWR from 'swr'
+
+import { getTopArticlesWithVaccine } from '../../api'
+import { ArticlePreview } from '../community/ArticlePreview'
+import { useCommunityStore, useTabStore } from '../../models'
+
+export default function DiscussionBlock(props: { vaccine_id: number }) {
+  const { data } = useSWR([props.vaccine_id, 'getTopArticlesWithVaccine'], ([vaccine_id]) =>
+    getTopArticlesWithVaccine(vaccine_id)
+  )
+
+  const isEmpty = !data || data.length === 0
+
+  return (
+    <>
+      <div className='px-4'>
+        {isEmpty ? (
+          <div className='flex flex-col items-center justify-center my-4'>
+            <div className='text-2xl font-bold'>暂无讨论</div>
+            <div className='text-gray-500'>快来发帖吧</div>
+          </div>
+        ) : (
+          data?.map((article, index) => {
+            return <ArticlePreview {...article} key={index} />
+          })
+        )}
+      </div>
+      <div className='py-6 flex justify-between'>
+        <ActionSendPost vaccine_id={props.vaccine_id} />
+        {isEmpty ? null : <ActionViewMore vaccine_id={props.vaccine_id} />}
+      </div>
+    </>
+  )
+}
+
+const ActionSendPost = (props: { vaccine_id: number }) => {
+  const handleSendPost = () => Taro.navigateTo({ url: '/pages/sendpost/index?vaccineID=' + props.vaccine_id })
+
+  return <ActionButton onClick={handleSendPost} text='发帖' icon={<Uploader size={16} />} />
+}
+
+const ActionViewMore = (props: { vaccine_id: number }) => {
+  const setTabIndexToCommunity = useTabStore((state) => () => {
+    state.setTabIndex(3)
+  })
+
+  const setCommunityFilterToVaccine = useCommunityStore((state) => () => {
+    state.setFilter(props.vaccine_id)
+  })
+
+  const handleViewMore = () => {
+    setTabIndexToCommunity()
+    setCommunityFilterToVaccine()
+    Taro.reLaunch({ url: '/pages/index' })
+  }
+
+  return <ActionButton onClick={handleViewMore} text='更多' icon={<MoreX size={16} />} />
+}
+
+function ActionButton(props: { onClick: () => any; icon?: React.ReactNode; text: string }) {
+  return (
+    <div
+      className={clsx(
+        'flex-grow flex gap-x-2 font-semibold justify-center text-brand items-center rounded-2xl mx-4 py-2 bg-gray-100',
+        'active:scale-105'
+      )}
+      onClick={props.onClick}
+    >
+      {props.icon}
+      {props.text}
+    </div>
+  )
+}

--- a/src/pages/vacDetails/header.tsx
+++ b/src/pages/vacDetails/header.tsx
@@ -1,0 +1,62 @@
+import { Follow, HeartFill1 } from '@nutui/icons-react-taro'
+import clsx from 'clsx'
+
+import { followVaccine, unfollowVaccine } from '../../api/methods'
+import { useUserFollowing, useVaccines } from '../../api/hooks'
+
+export default function Header(props: { activeId: number; vaccine_id: number; setActiveId: (id: number) => any }) {
+  const titles = ['疫苗介绍', '注意事项', '目标病症', '大家讨论']
+  const { id2name } = useVaccines()
+
+  return (
+    <header className='h-28 shadow-sm'>
+      <nav id='foo' className='fixed z-20 w-full backdrop-blur-md bg-gradient-to-b from-white to-white/80'>
+        <div className='m-auto px-6 md:px-12'>
+          <div className='flex flex-wrap items-center justify-between gap-6 py-3'>
+            <div className='flex w-full items-center justify-between'>
+              <a className='flex items-center space-x-2'>
+                <span className='text-2xl font-bold'>{id2name(props.vaccine_id)}</span>
+              </a>
+              <FollowButton vaccine_id={props.vaccine_id} />
+            </div>
+          </div>
+        </div>
+        <ul className='flex items-center px-4 gap-4 overflow-x-scroll whitespace-nowrap transition-all h-12'>
+          {titles?.map((title, index) => (
+            <li
+              key={index}
+              className={clsx(
+                'flex items-center justify-center px-2 py-2 text-sm font-medium rounded-full',
+                'transition-colors',
+                {
+                  'bg-slate-100 text-brand': props.activeId === index,
+                }
+              )}
+              onClick={() => props.setActiveId(index)}
+            >
+              {title}
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  )
+}
+
+const FollowButton = (props: { vaccine_id: number }) => {
+  const { checkVaccineFollowed: isVaccineFollowed, mutate } = useUserFollowing()
+  const handleFollowClick = async () => {
+    await followVaccine(props.vaccine_id)
+    mutate()
+  }
+  const handleUnfollowClick = async () => {
+    await unfollowVaccine(props.vaccine_id)
+    mutate()
+  }
+  const following = isVaccineFollowed(props.vaccine_id)
+  return following ? (
+    <HeartFill1 className='text-brand' size={16} onClick={handleUnfollowClick}></HeartFill1>
+  ) : (
+    <Follow className='text-brand' size={16} onClick={handleFollowClick}></Follow>
+  )
+}

--- a/src/pages/vacDetails/index.tsx
+++ b/src/pages/vacDetails/index.tsx
@@ -1,15 +1,12 @@
 import { useState } from 'react'
 import { useRouter } from 'taro-hooks'
 import { ScrollView, Text } from '@tarojs/components'
-import { Follow, HeartFill1, Uploader } from '@nutui/icons-react-taro'
 import { Loading } from '@nutui/nutui-react-taro'
-import Taro from '@tarojs/taro'
 import clsx from 'clsx'
-import useSWR from 'swr'
 
-import Tab from './tab'
-import { followVaccine, getVaccineByID, unfollowVaccine } from '../../api/methods'
-import { useUserFollowing } from '../../api/hooks'
+import Header from './header'
+import DiscussionBlock from './discussion'
+import { useVaccines } from '../../api'
 
 export default function Index() {
   const [route] = useRouter()
@@ -17,62 +14,43 @@ export default function Index() {
 
   const [tabIdx, setTabIdx] = useState(0)
 
-  const { data: vaccine } = useSWR('/api/vaccines/' + id, () => getVaccineByID(id))
+  const { data } = useVaccines()
+  const vaccine = data?.find((v) => v.ID === parseInt(id))
+
+  const activeId = 'detailTab' + tabIdx
 
   if (!vaccine) return <Loading className='w-screen h-screen'></Loading>
 
-  const tabs = ['疫苗介绍', '注意事项', '目标病症', '大家讨论']
-  const activeId = 'detailTab' + tabIdx
-
   return (
     <div className='flex h-screen w-screen flex-col'>
-      <div className='flex py-8 w-full flex-row items-center justify-between'>
-        <label className='ml-4 text-2xl font-bold'>{vaccine.name}</label>
-        <div className='mr-4 flex flex-row'>
-          <FollowButton vaccine_id={vaccine.ID} />
-        </div>
-      </div>
-      <div className='flex h-full w-full flex-col rounded-3xl bg-slate-100'>
-        <Tab titles={tabs} value={tabIdx} setValue={setTabIdx} />
-        <ScrollView className='self-center h-[72vh]' scrollY scrollWithAnimation scrollIntoView={activeId}>
-          <DetailBlock
-            id='detailTab0'
-            title='疫苗介绍'
-            paragraph={vaccine.description}
-            activeId={activeId}
-          ></DetailBlock>
-          <DetailBlock
-            id='detailTab1'
-            title='注意事项'
-            paragraph={vaccine.precautions + '\n' + vaccine.sideEffects}
-            activeId={activeId}
-          ></DetailBlock>
-          <DetailBlock
-            id='detailTab2'
-            title='目标病症'
-            paragraph={vaccine.targetDisease}
-            activeId={activeId}
-          ></DetailBlock>
-          <DetailBlock id='detailTab3' title='大家讨论' paragraph='暂无' activeId={activeId}></DetailBlock>
-          <div
-            className={clsx('flex justify-center items-center rounded-2xl mx-4 py-2 bg-slate-200', 'active:scale-105')}
-            onClick={() => Taro.navigateTo({ url: '/pages/sendpost/index?vacName=' + vaccine.name })}
-          >
-            <Uploader className='text-brand'></Uploader>
-          </div>
-        </ScrollView>
-      </div>
+      <Header activeId={tabIdx} vaccine_id={vaccine.ID} setActiveId={setTabIdx} />
+      <ScrollView style={{ height: 'calc(100vh - 7rem)' }} scrollY scrollWithAnimation scrollIntoView={activeId}>
+        <DetailBlock
+          id='detailTab0'
+          title='疫苗介绍'
+          paragraph={vaccine?.description}
+          activeId={activeId}
+        ></DetailBlock>
+        <DetailBlock
+          id='detailTab1'
+          title='注意事项'
+          paragraph={vaccine.precautions + '\n' + vaccine.sideEffects}
+          activeId={activeId}
+        ></DetailBlock>
+        <DetailBlock
+          id='detailTab2'
+          title='目标病症'
+          paragraph={vaccine.targetDisease}
+          activeId={activeId}
+        ></DetailBlock>
+        <DetailBlock id='detailTab3' title='大家讨论' activeId={activeId}></DetailBlock>
+        <DiscussionBlock vaccine_id={vaccine.ID} />
+      </ScrollView>
     </div>
   )
 }
 
-type BlockProps = {
-  id: string
-  title: string
-  paragraph: string
-  activeId: string
-}
-function DetailBlock(props: BlockProps) {
+function DetailBlock(props: { id: string; title: string; paragraph?: string; activeId: string }) {
   return (
     <div id={props.id} className='p-4'>
       <header
@@ -82,25 +60,13 @@ function DetailBlock(props: BlockProps) {
       >
         {props.title}
       </header>
-      <Text className='text-base'>{props.paragraph}</Text>
+      {props.paragraph ? (
+        <div className='px-2'>
+          <Text userSelect className='text-base'>
+            {props.paragraph}
+          </Text>
+        </div>
+      ) : null}
     </div>
-  )
-}
-
-const FollowButton = (props: { vaccine_id: number }) => {
-  const { data: user, mutate } = useUserFollowing()
-  const handleFollowClick = async () => {
-    await followVaccine(props.vaccine_id)
-    mutate()
-  }
-  const handleUnfollowClick = async () => {
-    await unfollowVaccine(props.vaccine_id)
-    mutate()
-  }
-  const following = user?.followingVaccines?.find((v) => v.ID === props.vaccine_id) !== undefined
-  return following ? (
-    <HeartFill1 className='text-brand' size={16} onClick={handleUnfollowClick}></HeartFill1>
-  ) : (
-    <Follow className='text-brand' size={16} onClick={handleFollowClick}></Follow>
   )
 }

--- a/src/tabbar/actionsheet.tsx
+++ b/src/tabbar/actionsheet.tsx
@@ -1,13 +1,15 @@
-import { ActionSheet } from '@nutui/nutui-react-taro'
-import { useRouter } from 'taro-hooks'
-import { create } from 'zustand'
+import Taro from '@tarojs/taro'
+import { ActionSheet, Divider } from '@nutui/nutui-react-taro'
+import { useTabStore } from '../models'
 
 export default function ButtonActionSheet() {
-  const [isVisible, setIsVisible] = useActionStore((state) => [state.actionVisible, state.setActionVisible])
+  const isVisible = useTabStore.use.actionVisible()
+  const setIsVisible = useTabStore.use.setActionVisible()
 
-  const [, { navigate }] = useRouter()
-
-  const navDual = (url: string) => () => navigate(url).finally(useActionReset)
+  const navDual = (url: string) => () => {
+    setIsVisible(false)
+    Taro.navigateTo({ url })
+  }
 
   return (
     <ActionSheet
@@ -17,25 +19,17 @@ export default function ButtonActionSheet() {
       }}
       onCancel={() => setIsVisible(false)}
     >
-      <div style={{ textAlign: 'left', padding: '10px 20px' }}>免疫接种</div>
-      <div style={{ textAlign: 'left', padding: '10px 20px' }}>预约提醒</div>
-      <div style={{ textAlign: 'left', padding: '10px 20px' }} onClick={navDual('/pages/sendpost/index')}>
-        我要发帖
+      <div className='px-4 py-3 font-medium' onClick={navDual('/pages/record/index')}>
+        +免疫接种
       </div>
-      <div style={{ textAlign: 'left', padding: '10px 20px' }}>体温测量</div>
+      <Divider />
+      <div className='px-4 py-3 font-medium' onClick={navDual('/pages/temper/index')}>
+        +体温测量
+      </div>
+      <Divider />
+      <div className='px-4 py-3 font-medium' onClick={navDual('/pages/sendpost/index')}>
+        +我要发帖
+      </div>
     </ActionSheet>
   )
-}
-
-interface IActionStore {
-  actionVisible: boolean
-  setActionVisible: (visible: boolean) => void
-}
-export const useActionStore = create<IActionStore>()((set) => ({
-  actionVisible: false,
-  setActionVisible: (visible: boolean) => set((_state) => ({ actionVisible: visible })),
-}))
-
-export function useActionReset() {
-  useActionStore.setState({ actionVisible: false })
 }

--- a/src/tabbar/index.tsx
+++ b/src/tabbar/index.tsx
@@ -1,18 +1,16 @@
 import { Tabbar, Button } from '@nutui/nutui-react-taro'
 import { Home, Search, Find, Uploader, My } from '@nutui/icons-react-taro'
-import { useEffect } from 'react'
 
 import './index.css'
 
 import { useTabStore } from '../models'
-import ButtonActionSheet, { useActionStore, useActionReset } from './actionsheet'
+import ButtonActionSheet from './actionsheet'
 
 function CustomTabBar() {
   const setTabIndex = useTabStore((state) => state.setTabIndex)
   const tabIndex = useTabStore((state) => state.tabIndex)
 
-  const setIsVisible = useActionStore((state) => state.setActionVisible)
-  useEffect(useActionReset, [])
+  const setIsVisible = useTabStore((state) => state.setActionVisible)
 
   return (
     <>


### PR DESCRIPTION
- 现在每个用户显示的数据应该是独立的了
- 疫苗查询能够根据收藏、接种状态进行不同的渲染
- 疫苗详情页面植入了社区内容

其他
- 底部“+”按钮移除了“预约提醒”
- 把组件里的api.request换成外部管理的方法
- 服务器废弃了接种记录的vaccine字段，修改了前端代码来正确显示疫苗名
- 使用useCallBack进行了一些优化